### PR TITLE
Add ADLS Gen2 Delta connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,44 @@
+# ADLS Gen2 Delta Connector
+
+This module provides a simple connector for reading data from Azure Data Lake Storage Gen2 that is stored in either Delta Lake or Parquet format. The connector supports authentication using Managed Identity or a Service Principal.
+
+## Installation
+
+Install the required dependencies:
+
+```bash
+pip install adlfs deltalake azure-identity pandas
+```
+
+## Usage
+
+```python
+from adls_delta_connector import ADLSConfig, ADLSDeltaConnector
+
+config = ADLSConfig(
+    account_name="<storage-account>",
+    filesystem="<filesystem>",  # e.g. "my-container"
+    path="path/to/table",  # path to the delta table or parquet file
+    file_format="delta",  # or "parquet"
+    connection_type="mi"  # or "spn"
+)
+
+# For service principal authentication
+# config = ADLSConfig(
+#     account_name="<storage-account>",
+#     filesystem="<filesystem>",
+#     path="path/to/table",
+#     file_format="delta",
+#     connection_type="spn",
+#     tenant_id="<tenant>",
+#     client_id="<client-id>",
+#     client_secret="<secret>"
+# )
+
+connector = ADLSDeltaConnector(config)
+
+df = connector.read()
+print(df.head())
+```
+
+This will return a `pandas.DataFrame` containing the data stored in the specified Delta Lake table or Parquet file.

--- a/adls_delta_connector.py
+++ b/adls_delta_connector.py
@@ -1,0 +1,59 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import pandas as pd
+from azure.identity import ManagedIdentityCredential, ClientSecretCredential
+import adlfs
+try:
+    from deltalake import DeltaTable
+except ImportError:  # optional dependency
+    DeltaTable = None
+
+
+@dataclass
+class ADLSConfig:
+    account_name: str
+    filesystem: str
+    path: str
+    file_format: str = "delta"  # 'delta' or 'parquet'
+    connection_type: str = "mi"  # 'mi' or 'spn'
+    tenant_id: Optional[str] = None
+    client_id: Optional[str] = None
+    client_secret: Optional[str] = None
+
+
+class ADLSDeltaConnector:
+    def __init__(self, config: ADLSConfig):
+        self.config = config
+        self.fs = self._create_filesystem()
+
+    def _create_filesystem(self):
+        if self.config.connection_type.lower() == "mi":
+            credential = ManagedIdentityCredential()
+        elif self.config.connection_type.lower() == "spn":
+            if not all([self.config.tenant_id, self.config.client_id, self.config.client_secret]):
+                raise ValueError("SPN requires tenant_id, client_id, and client_secret")
+            credential = ClientSecretCredential(
+                tenant_id=self.config.tenant_id,
+                client_id=self.config.client_id,
+                client_secret=self.config.client_secret,
+            )
+        else:
+            raise ValueError(f"Unsupported connection type: {self.config.connection_type}")
+
+        return adlfs.AzureBlobFileSystem(account_name=self.config.account_name, credential=credential)
+
+    def read(self) -> pd.DataFrame:
+        abfs_path = f"abfs://{self.config.filesystem}/{self.config.path}"
+        file_format = self.config.file_format.lower()
+
+        if file_format == "delta":
+            if DeltaTable is None:
+                raise ImportError("deltalake package is required for reading delta format")
+            dt = DeltaTable(abfs_path, filesystem=self.fs)
+            return dt.to_pandas()
+        elif file_format == "parquet":
+            with self.fs.open(abfs_path, "rb") as f:
+                return pd.read_parquet(f)
+        else:
+            raise ValueError(f"Unsupported file format: {self.config.file_format}")


### PR DESCRIPTION
## Summary
- implement a reusable ADLS Gen2 connector that can read Delta or Parquet formats
- document usage and installation in README

## Testing
- `python -m py_compile adls_delta_connector.py`
- `python - <<'PY'
from adls_delta_connector import ADLSConfig, ADLSDeltaConnector
print('module loaded')
PY
`

------
https://chatgpt.com/codex/tasks/task_e_6850ca8e49c0832ea439f687d1c72fe3