### PR TITLE
Add DataRetriever utility for unified access

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,35 @@ connector = AzureSQLConnector(config)
 df = connector.query("SELECT * FROM mytable")
 print(df.head())
 ```
+
+# Data Retriever
+
+The `DataRetriever` class provides a single interface for retrieving data from either ADLS or Azure SQL based on a configuration.
+
+```python
+from data_retriever import DataRetriever, RetrieverConfig
+from adls_delta_connector import ADLSConfig
+from azure_sql_connector import AzureSQLConfig
+
+# Example for ADLS
+adls_cfg = ADLSConfig(
+    account_name="<storage-account>",
+    filesystem="<filesystem>",
+    path="path/to/table",
+)
+retriever = DataRetriever(RetrieverConfig(source_type="adls", adls_config=adls_cfg))
+
+adls_df = retriever.retrieve()
+
+# Example for Azure SQL
+sql_cfg = AzureSQLConfig(
+    server="<server>.database.windows.net",
+    database="<database>",
+)
+retriever = DataRetriever(RetrieverConfig(source_type="sql", sql_config=sql_cfg))
+
+sql_df = retriever.retrieve("SELECT * FROM mytable")
+```
+
+This will return a `pandas.DataFrame` with the results from the chosen source.
+

--- a/data_retriever.py
+++ b/data_retriever.py
@@ -1,0 +1,41 @@
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import pandas as pd
+
+from azure_sql_connector import AzureSQLConfig, AzureSQLConnector
+from adls_delta_connector import ADLSConfig, ADLSDeltaConnector
+
+
+@dataclass
+class RetrieverConfig:
+    """Configuration for the DataRetriever."""
+
+    source_type: str  # "sql" or "adls"
+    sql_config: Optional[AzureSQLConfig] = None
+    adls_config: Optional[ADLSConfig] = None
+
+
+class DataRetriever:
+    """Retrieve data from SQL or ADLS based on configuration."""
+
+    def __init__(self, config: RetrieverConfig):
+        self.config = config
+        stype = config.source_type.lower()
+        if stype == "sql":
+            if not config.sql_config:
+                raise ValueError("sql_config must be provided when source_type is 'sql'")
+            self.client = AzureSQLConnector(config.sql_config)
+        elif stype == "adls":
+            if not config.adls_config:
+                raise ValueError("adls_config must be provided when source_type is 'adls'")
+            self.client = ADLSDeltaConnector(config.adls_config)
+        else:
+            raise ValueError(f"Unsupported source_type: {config.source_type}")
+
+    def retrieve(self, *args, **kwargs) -> pd.DataFrame:
+        """Retrieve data using the underlying connector."""
+        if isinstance(self.client, AzureSQLConnector):
+            return self.client.query(*args, **kwargs)
+        else:
+            return self.client.read()


### PR DESCRIPTION
## Summary
- add `data_retriever` module to call either SQL or ADLS based on config
- document usage of `DataRetriever` in README

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6850e9c6a944832ebcf8c1306f1b1284